### PR TITLE
Fix EZP-21558: Changed working folder to storageDirectory

### DIFF
--- a/classes/image_pre_action.php
+++ b/classes/image_pre_action.php
@@ -80,7 +80,7 @@ class eZIEImagePreAction
         }
 
         // we could store the images in var/xxx/cache/public
-        $this->working_folder = eZSys::cacheDirectory() . "/public/ezie/" . $this->key;
+        $this->working_folder = eZSys::storageDirectory() . "/public/ezie/" . $this->key;
 
         $this->image_path =
             $this->working_folder . "/" .

--- a/modules/ezie/prepare.php
+++ b/modules/ezie/prepare.php
@@ -32,7 +32,7 @@ $absolute_image_path = eZSys::rootDir() . "/{$image_path}";
 $user = eZUser::instance();
 
 $working_folder_path =
-    eZSys::cacheDirectory() . '/public/ezie/' .
+    eZSys::storageDirectory() . '/public/ezie/' .
     $user->id() . "/{$attributeID}-{$version}";
 $working_folder_absolute_path = eZSys::rootDir() . "/{$working_folder_path}";
 


### PR DESCRIPTION
Starting with the implementation of ezsystems/ezpublish-legacy#750, eZ Image Editor stopped working.

eZIE works with the cache directory for creating copies and thumbnails of the images. When making the initial copies, the paths of the copies are stored in the `ezdfsfile` table.

When later trying to fetch those copies (by file path), the files are searched in the `ezdfsfile_cache` table, which can't be found there, breaking the Image Editor.

With this patch, the working dir is changed from the cache dir to the storage dir. This ensures that all images will be stored in the same ezdfsfile\* table.

Cheers
:octocat: Jérôme
