### PR TITLE
Fix EZP-22025: use a real cluster file scope

### DIFF
--- a/classes/image_converter.php
+++ b/classes/image_converter.php
@@ -114,7 +114,7 @@ class eZIEezcImageConverter
         $outClusterHandler = eZClusterFileHandler::instance();
 
         // @todo Check if the local output file can be deleted at that stage. Theorically yes.
-        $outClusterHandler->fileStore( $dst, true );
+        $outClusterHandler->fileStore( $dst, 'image' );
         
         // fixing the file permissions
         eZImageHandler::changeFilePermissions( $dst );


### PR DESCRIPTION
'true' was passed as the scope when storing the file to cluster.
